### PR TITLE
Clean up notebooks using mast-aladin-lite

### DIFF
--- a/notebooks/AIDA_mixin_get_viewport.ipynb
+++ b/notebooks/AIDA_mixin_get_viewport.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "# Adding a footprint for easy visual reference of functionality\n",
-    "# aladin-lite can load a footprint from an STC-S string like this one:\n",
+    "# mast-aladin can load a footprint from an STC-S string like this one:\n",
     "stcs_string = \"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\"\n",
     "mast_aladin.add_graphic_overlay_from_stcs(stcs_string)"
    ]
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Raises NotImplementedError since aladin-lite has no concept of pixels\n",
+    "# Raises NotImplementedError since mast-aladin has no concept of pixels\n",
     "mast_aladin.aid.get_viewport(sky_or_pixel=\"pixel\")"
    ]
   },
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Raises warning since aladin-lite only shows one image and has no concept of labels\n",
+    "# Raises warning since mast-aladin only shows one image and has no concept of labels\n",
     "mast_aladin.aid.get_viewport(image_label = \"image1\")"
    ]
   },

--- a/notebooks/AIDA_mixin_getset_viewport_with_rotation.ipynb
+++ b/notebooks/AIDA_mixin_getset_viewport_with_rotation.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "# Adding a footprint for easy visual reference of functionality\n",
-    "# aladin-lite can load a footprint from an STC-S string like this one:\n",
+    "# mast-aladin can load a footprint from an STC-S string like this one:\n",
     "stcs_string = \"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\"\n",
     "mast_aladin.add_graphic_overlay_from_stcs(stcs_string)"
    ]
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Raises NotImplementedError since aladin-lite has no concept of pixels\n",
+    "# Raises NotImplementedError since mast-aladin has no concept of pixels\n",
     "mast_aladin.aid.get_viewport(sky_or_pixel=\"pixel\")"
    ]
   },
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Raises warning since aladin-lite only shows one image and has no concept of labels\n",
+    "# Raises warning since mast-aladin only shows one image and has no concept of labels\n",
     "mast_aladin.aid.get_viewport(image_label = \"image1\")"
    ]
   },

--- a/notebooks/AIDA_mixin_set_viewport.ipynb
+++ b/notebooks/AIDA_mixin_set_viewport.ipynb
@@ -36,7 +36,7 @@
    "outputs": [],
    "source": [
     "# Adding a footprint for easy visual reference of functionality\n",
-    "# aladin-lite can load a footprint from an STC-S string like this one:\n",
+    "# mast-aladin can load a footprint from an STC-S string like this one:\n",
     "stcs_string = \"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\"\n",
     "mast_aladin.add_graphic_overlay_from_stcs(stcs_string)"
    ]

--- a/notebooks/Intro_To_Mast_Aladin.ipynb
+++ b/notebooks/Intro_To_Mast_Aladin.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "source": [
     "## Installing MastAladin\n",
-    "Before we get started, let’s make sure we’re using the latest version of MastAladinLite.\n",
+    "Before we get started, let’s make sure we’re using the latest version of MastAladin.\n",
     "We’ll install it directly from the official GitHub repository so this tutorial reflects the most recent features and fixes."
    ]
   },

--- a/notebooks/JWST_L2L3_Demo.ipynb
+++ b/notebooks/JWST_L2L3_Demo.ipynb
@@ -100,7 +100,7 @@
    "id": "0a8baeb0-024d-4e60-9747-b21bbb4261ca",
    "metadata": {},
    "source": [
-    "## Setup mast-aladin-lite for display"
+    "## Setup mast-aladin for display"
    ]
   },
   {

--- a/notebooks/demo-select-MAST-products.ipynb
+++ b/notebooks/demo-select-MAST-products.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Select observations and data products from MAST\n",
-    "#### and load data products into `jdaviz` and `mast_aladin_lite`"
+    "#### and load data products into `jdaviz` and `mast_aladin`"
    ]
   },
   {
@@ -28,7 +28,6 @@
     "from astropy.coordinates import SkyCoord\n",
     "\n",
     "from astroquery.mast import MastMissions\n",
-    "from astropy.table import Table\n",
     "from mast_aladin import MastTable, AppSidecar\n",
     "\n",
     "mission = 'JWST'\n",
@@ -118,7 +117,7 @@
    "id": "d25e9c3b-be58-48d3-9a89-e11fab6563d1",
    "metadata": {},
    "source": [
-    "Pop open a sidecar with `jdaviz` and `mast-aladin-lite`:"
+    "Pop open a sidecar with `jdaviz` and `mast-aladin`:"
    ]
   },
   {
@@ -136,11 +135,11 @@
    "id": "c770e3a0-147d-4b2a-83e3-8e2c22288aea",
    "metadata": {},
    "source": [
-    "Now that we've selected a file, we can download the file and open it with `jdaviz` and/or `mast-aladin-lite` in a sidecar.\n",
+    "Now that we've selected a file, we can download the file and open it with `jdaviz` and/or `mast-aladin` in a sidecar.\n",
     "\n",
     "Either click the `jdaviz` and `aladin` buttons at the bottom of the `MastTable` widget, or use the API commands below to do the same thing.\n",
     "\n",
-    "If working in `mast-aladin-lite`, zoom into the region of interest to see the file. You can do this by running `mast_aladin.aid.set_viewport(fov = 0.25)`!"
+    "If working in `mast-aladin`, zoom into the region of interest to see the file. You can do this by running `mast_aladin.aid.set_viewport(fov = 0.25)`!"
    ]
   },
   {

--- a/notebooks/demo-select-MAST-roman-products.ipynb
+++ b/notebooks/demo-select-MAST-roman-products.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Select observations and data products from MAST\n",
-    "#### and load data products into `jdaviz` and `mast_aladin_lite`"
+    "#### and load data products into `jdaviz` and `mast_aladin`"
    ]
   },
   {
@@ -39,8 +39,7 @@
     "from astropy.coordinates import SkyCoord\n",
     "\n",
     "from astroquery.mast import MastMissions\n",
-    "from astropy.table import Table\n",
-    "from mast_aladin_lite import MastTable, AppSidecar\n",
+    "from mast_aladin import MastTable, AppSidecar\n",
     "\n",
     "\n",
     "target = SkyCoord(ra=270, dec=66, unit='deg')\n",
@@ -143,7 +142,7 @@
    "id": "d25e9c3b-be58-48d3-9a89-e11fab6563d1",
    "metadata": {},
    "source": [
-    "Pop open a sidecar with `jdaviz` and `mast-aladin-lite`:"
+    "Pop open a sidecar with `jdaviz` and `mast-aladin`:"
    ]
   },
   {

--- a/notebooks/demo-sidecar-launcher.ipynb
+++ b/notebooks/demo-sidecar-launcher.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "from jdaviz import Imviz\n",
-    "from mast_aladin_lite import MastAladin\n",
+    "from mast_aladin import MastAladin\n",
     "\n",
     "viz = Imviz()\n",
     "mal_1 = MastAladin()\n",
@@ -138,7 +138,7 @@
    "id": "4fe03c73-6ab4-4703-a575-da89c7232ba1",
    "metadata": {},
    "source": [
-    "By default, there is no requirement to have both `mast-aladin-lite` and `jdaviz` in the result. \n",
+    "By default, there is no requirement to have both `mast-aladin` and `jdaviz` in the result. \n",
     "\n",
     "You can make sure there are at least one instance of either app with: `include_jdaviz=True` and/or `include_aladin=True`."
    ]

--- a/notebooks/view_sync_example.ipynb
+++ b/notebooks/view_sync_example.ipynb
@@ -6,13 +6,13 @@
    "metadata": {},
    "source": [
     "# View Sync Example Notebook\n",
-    "The following notebook demonstrates the syncing of Mast Aladin and Imviz viewers through a sample UI.\n",
+    "The following notebook demonstrates the syncing of MastAladin and Imviz viewers through a sample UI.\n",
     "\n",
     "### How it works\n",
-    "Simply create an instance of Mast Aladin and Imviz, then the UI will utilize methods on both apps to retrieve the current instances you defined. The UI will then display an example layout of both viewers along with controls to manage the syncing of views between them.\n",
+    "Simply create an instance of MastAladin and Imviz, then the UI will utilize methods on both apps to retrieve the current instances you defined. The UI will then display an example layout of both viewers along with controls to manage the syncing of views between them.\n",
     "\n",
     "### Tips\n",
-    "Once you load the UI, try the \"Sync to Imviz\" button to update the zoom level on the Mast Aladin Lite viewer to bring the Cartwheel Galaxy into view."
+    "Once you load the UI, try the \"Sync to Imviz\" button to update the zoom level on the MastAladin viewer to bring the Cartwheel Galaxy into view."
    ]
   },
   {
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "from mast_aladin import MastAladin\n",
-    "from mast_aladin_lite.adapters import ViewerSyncUI\n",
+    "from mast_aladin.adapters import ViewerSyncUI\n",
     "from jdaviz import Imviz\n",
     "\n",
     "import warnings"
@@ -97,7 +97,7 @@
    "metadata": {},
    "source": [
     "### Sync Rotation\n",
-    "Try clicking the button in the UI to sync to `Mast Aladin` and then update the rotation of the `aladin_viewer` manually. You should see that `imviz` updates accordingly. The orientation plugin will also have a new orientation option selected corresponding to the aladin rotation."
+    "Try clicking the button in the UI to sync to `MastAladin` and then update the rotation of the `aladin_viewer` manually. You should see that `imviz` updates accordingly. The orientation plugin will also have a new orientation option selected corresponding to the aladin rotation."
    ]
   },
   {


### PR DESCRIPTION
editing some ipynbs that were still using `mast-aladin-lite` instead of `mast-aladin`. A few other assorted small issues fixed along the way